### PR TITLE
Add data_loss_prevention_discovery_config support for OtherCloudDiscoveryTarget, which currently only supports AWS S3 buckets.

### DIFF
--- a/.ci/infra/terraform/main.tf
+++ b/.ci/infra/terraform/main.tf
@@ -165,6 +165,18 @@ resource "google_organization_iam_member" "sa_principal_access_boundary_admin" {
   member = google_service_account.sa.member
 }
 
+resource "google_organization_iam_member" "dlp_admin" {
+  org_id = data.google_organization.org.org_id
+  role   = "roles/dlp.admin"
+  member = google_service_account.sa.member
+}
+
+resource "google_organization_iam_member" "dlp_org_driver" {
+  org_id = data.google_organization.org.org_id
+  role   = "roles/dlp.orgDriver"
+  member = "serviceAccount:service-${google_project.proj.number}@dlp-api.iam.gserviceaccount.com"
+}
+
 resource "google_billing_account_iam_member" "sa_master_billing_admin" {
   billing_account_id = data.google_billing_account.master_acct.id
   role               = "roles/billing.admin"

--- a/mmv1/products/dlp/DiscoveryConfig.yaml
+++ b/mmv1/products/dlp/DiscoveryConfig.yaml
@@ -125,6 +125,25 @@ properties:
           - name: 'folderId'
             type: String
             description: The ID for the folder within an organization to scan
+  - name: 'otherCloudStartingLocation'
+    type: NestedObject
+    properties:
+      - name: 'awsLocation'
+        type: NestedObject
+        properties:
+          - name: 'accountId'
+            type: String
+            conflicts:
+              - other_cloud_starting_location.aws_location.all_assets_inventory_assets
+            description: 'The AWS account ID that this discovery config applies to.
+              Within an organization, you can find the AWS account ID inside an AWS account ARN.
+              Example:
+              arn:<partition>:organizations::<management-account-id>:account/<organization-id>/<account-id>'
+          - name: 'allAssetInventoryAssets'
+            type: Boolean
+            conflicts:
+              - other_cloud_starting_location.aws_location.account_id
+            description: All AWS assets stored in Asset Inventory that didn't match other AWS discovery configs.
   - name: 'inspectTemplates'
     type: Array
     description: Detection logic for profile generation
@@ -290,11 +309,11 @@ properties:
                 - name: 'otherTables'
                   type: NestedObject
                   description: Catch-all. This should always be the last filter in the list because anything above it will apply first.
-                    # The fields below are necessary to include the "otherTables" filter in the payload
+                  # The fields below are necessary to include the "otherTables" filter in the payload
                   send_empty_value: true
                   allow_empty_object: true
                   properties:
- # Meant to be an empty object with no properties - see here : https://cloud.google.com/sensitive-data-protection/docs/reference/rest/v2/organizations.locations.discoveryConfigs#allotherbigquerytables
+                  # Meant to be an empty object with no properties - see here : https://cloud.google.com/sensitive-data-protection/docs/reference/rest/v2/organizations.locations.discoveryConfigs#allotherbigquerytables
                     []
                 - name: 'tableReference'
                   type: NestedObject
@@ -411,7 +430,7 @@ properties:
               send_empty_value: true
               allow_empty_object: true
               properties:
- # Meant to be an empty object with no properties - see here : https://cloud.google.com/sensitive-data-protection/docs/reference/rest/v2/organizations.locations.discoveryConfigs#disabled
+                # Meant to be an empty object with no properties - see here : https://cloud.google.com/sensitive-data-protection/docs/reference/rest/v2/organizations.locations.discoveryConfigs#disabled
                 []
         - name: 'cloudSqlTarget'
           type: NestedObject
@@ -454,7 +473,7 @@ properties:
                   send_empty_value: true
                   allow_empty_object: true
                   properties:
- # Meant to be an empty object with no properties. The fields below are necessary to include the "others" filter in the payload
+                    # Meant to be an empty object with no properties. The fields below are necessary to include the "others" filter in the payload
                     []
                 - name: 'databaseResourceReference'
                   type: NestedObject
@@ -562,7 +581,7 @@ properties:
           send_empty_value: true
           allow_empty_object: true
           properties:
- # Meant to be an empty object with no properties - see here : https://cloud.google.com/sensitive-data-protection/docs/reference/rest/v2/organizations.locations.discoveryConfigs#DiscoveryConfig.SecretsDiscoveryTarget
+            # Meant to be an empty object with no properties - see here : https://cloud.google.com/sensitive-data-protection/docs/reference/rest/v2/organizations.locations.discoveryConfigs#DiscoveryConfig.SecretsDiscoveryTarget
             []
         - name: 'cloudStorageTarget'
           type: NestedObject
@@ -613,7 +632,7 @@ properties:
                   send_empty_value: true
                   allow_empty_object: true
                   properties:
- # Meant to be an empty object with no properties. The fields below are necessary to include the "others" filter in the payload
+                    # Meant to be an empty object with no properties. The fields below are necessary to include the "others" filter in the payload
                     []
             - name: 'conditions'
               type: NestedObject
@@ -687,6 +706,144 @@ properties:
               allow_empty_object: true
               properties:
                 []
+        - name: 'otherCloudTarget'
+          type: NestedObject
+          description: Other clouds target for discovery. The first target to match a resource will be the one applied.
+          properties:
+            - name: 'dataSourceType'
+              type: NestedObject
+              description: 'Required. The type of data profiles generated by this discovery target. Supported values are: aws/s3/bucket'
+              properties:
+                - name: 'dataSource'
+                  type: String
+            - name: 'filter'
+              type: NestedObject
+              description: 'Required. The resources that the discovery cadence applies to. The
+                first target with a matching filter will be the one to apply to a resource.'
+              required: true
+              properties:
+                - name: 'collection'
+                  type: NestedObject
+                  description: A collection of resources for this filter to apply to.
+                  properties:
+                    - name: 'includeRegexes'
+                      type: NestedObject
+                      description: A collection of regular expressions to match a resource against.
+                      properties:
+                        - name: 'patterns'
+                          type: Array
+                          description: The group of regular expression patterns to match against one or more resources. Maximum of 100 entries. The sum of all lengths of regular expressions can't exceed 10 KiB.
+                          item_type:
+                            type: NestedObject
+                            properties:
+                              - name: 'amazonS3BucketRegex'
+                                type: NestedObject
+                                description: Regex for Cloud Storage.
+                                properties:
+                                  - name: 'awsAccountRegex'
+                                    type: NestedObject
+                                    description: 'The AWS account regex'
+                                    properties:
+                                      - name: 'accountIdRegex'
+                                        type: String
+                                        description: 'Regex to test the AWS account ID against.
+                                          If empty, all accounts match.
+                                          Example: arn:aws:organizations::123:account/o-b2c3d4/345'
+                                  - name: 'bucketNameRegex'
+                                    type: String
+                                    description: 'Regex to test the bucket name against. If empty, all buckets match.'
+                - name: 'singleResource'
+                  type: NestedObject
+                  description: The resource to scan. Configs using this filter can only have one target (the target with this single resource reference).
+                  properties:
+                    - name: 'amazonS3Bucket'
+                      type: NestedObject
+                      description: Amazon S3 bucket.
+                      properties:
+                        - name: 'awsAccount'
+                          type: NestedObject
+                          description: The AWS account.
+                          properties:
+                            - name: 'accountId'
+                              type: String
+                              description: AWS account ID.
+                        - name: 'bucketName'
+                          type: String
+                          description: The bucket name.
+                - name: 'others'
+                  type: NestedObject
+                  description: Match discovery resources not covered by any other filter.
+                  send_empty_value: true
+                  allow_empty_object: true
+                  properties:
+                    # Meant to be an empty object with no properties. The fields below are necessary to include the "others" filter in the payload
+                    []
+            - name: 'conditions'
+              type: NestedObject
+              description: In addition to matching the filter, these conditions must be true before a profile is generated.
+              properties:
+                - name: 'minAge'
+                  type: String
+                  description: Duration format.  Minimum age a resource must be before a profile can be generated. Value must be 1 hour or greater. Minimum age is not supported for Azure Blob Storage containers.
+                - name: 'amazonS3BucketConditions'
+                  type: NestedObject
+                  description: Amazon S3 bucket conditions.
+                  properties:
+                    - name: 'bucketTypes'
+                      type: Array
+                      description: Bucket types that should be profiled. Optional. Defaults to TYPE_ALL_SUPPORTED if unspecified.
+                      item_type:
+                        type: Enum
+                        description: |
+                          This field only has a name and description because of MM
+                          limitations. It should not appear in downstreams.
+                        enum_values:
+                          - 'TYPE_ALL_SUPPORTED'
+                          - 'TYPE_GENERAL_PURPOSE'
+                    - name: 'objectStorageClasses'
+                      type: Array
+                      description: Object classes that should be profiled. Optional. Defaults to ALL_SUPPORTED_CLASSES if unspecified.
+                      item_type:
+                        type: Enum
+                        description: |
+                          This field only has a name and description because of MM
+                          limitations. It should not appear in downstreams.
+                        enum_values:
+                          - 'ALL_SUPPORTED_CLASSES'
+                          - 'STANDARD'
+                          - 'STANDARD_INFREQUENT_ACCESS'
+                          - 'GLACIER_INSTANT_RETRIEVAL'
+                          - 'INTELLIGENT_TIERING'
+            - name: 'generationCadence'
+              type: NestedObject
+              description: How often and when to update profiles. New resources that match both the filter and conditions are scanned as quickly as possible depending on system capacity.
+              properties:
+                - name: 'refreshFrequency'
+                  type: Enum
+                  description: Frequency to update profiles regardless of whether the underlying resource has changes. Defaults to never.
+                  enum_values:
+                    - 'UPDATE_FREQUENCY_NEVER'
+                    - 'UPDATE_FREQUENCY_DAILY'
+                    - 'UPDATE_FREQUENCY_MONTHLY'
+                - name: 'inspectTemplateModifiedCadence'
+                  type: NestedObject
+                  description: Governs when to update data profiles when the inspection rules defined by the `InspectTemplate` change. If not set, changing the template will not cause a data profile to update.
+                  properties:
+                    - name: 'frequency'
+                      type: Enum
+                      description: How frequently data profiles can be updated when the template is modified. Defaults to never.
+                      enum_values:
+                        - 'UPDATE_FREQUENCY_NEVER'
+                        - 'UPDATE_FREQUENCY_DAILY'
+                        - 'UPDATE_FREQUENCY_MONTHLY'
+            - name: 'disabled'
+              type: NestedObject
+              description: Disable profiling for resources that match this filter.
+              send_empty_value: true
+              allow_empty_object: true
+              properties:
+                []
+
   - name: 'errors'
     type: Array
     description: Output only. A stream of errors encountered when the config was activated. Repeated errors may result in the config automatically being paused. Output only field. Will return the last 100 errors. Whenever the config is modified this list will be cleared.

--- a/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_discovery_config_test.go
+++ b/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_discovery_config_test.go
@@ -21,6 +21,8 @@ func TestAccDataLossPreventionDiscoveryConfig_Update(t *testing.T) {
 		"secrets":    testAccDataLossPreventionDiscoveryConfig_SecretsUpdate,
 		"gcs":        testAccDataLossPreventionDiscoveryConfig_CloudStorageUpdate,
 		"gcs_single": testAccDataLossPreventionDiscoveryConfig_CloudStorageSingleBucket,
+		"aws_s3":     testAccDataLossPreventionDiscoveryConfig_AwsS3Update,
+		"aws_single": testAccDataLossPreventionDiscoveryConfig_AwsS3SingleBucket,
 	}
 	for name, tc := range testCases {
 		// shadow the tc variable into scope so that when
@@ -383,6 +385,94 @@ func testAccDataLossPreventionDiscoveryConfig_CloudStorageSingleBucket(t *testin
 			},
 			{
 				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigCloudStorageSingleUpdate(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
+			},
+		},
+	})
+}
+
+func testAccDataLossPreventionDiscoveryConfig_AwsS3Update(t *testing.T) {
+
+	context := map[string]interface{}{
+		"project":        envvar.GetTestProjectFromEnv(),
+		"organization":   envvar.GetTestOrgFromEnv(t),
+		"location":       envvar.GetTestRegionFromEnv(),
+		"random_suffix":  acctest.RandString(t, 10),
+		"project_number": envvar.GetTestProjectNumberFromEnv(),
+	}
+
+	acctest.BootstrapIamMembers(t, []acctest.IamMember{
+		{
+			Member: "serviceAccount:service-{project_number}@dlp-api.iam.gserviceaccount.com",
+			Role:   "roles/dlp.orgDriver",
+		},
+	})
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataLossPreventionDiscoveryConfigDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigStartAwsS3(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
+			},
+			{
+				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigUpdateAwsS3(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
+			},
+		},
+	})
+}
+
+func testAccDataLossPreventionDiscoveryConfig_AwsS3SingleBucket(t *testing.T) {
+
+	context := map[string]interface{}{
+		"project":        envvar.GetTestProjectFromEnv(),
+		"organization":   envvar.GetTestOrgFromEnv(t),
+		"location":       envvar.GetTestRegionFromEnv(),
+		"random_suffix":  acctest.RandString(t, 10),
+		"project_number": envvar.GetTestProjectNumberFromEnv(),
+	}
+
+	acctest.BootstrapIamMembers(t, []acctest.IamMember{
+		{
+			Member: "serviceAccount:service-{project_number}@dlp-api.iam.gserviceaccount.com",
+			Role:   "roles/dlp.orgDriver",
+		},
+	})
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataLossPreventionDiscoveryConfigDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigStartAwsS3(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
+			},
+			{
+				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigAwsS3SingleUpdate(context),
 			},
 			{
 				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
@@ -1278,6 +1368,240 @@ resource "google_data_loss_prevention_discovery_config" "basic" {
                 cloud_storage_resource_reference {
                     project_id = "%{project}"
                     bucket_name = google_storage_bucket.testbucket.name
+                }
+            }
+			generation_cadence {
+                inspect_template_modified_cadence {
+                    frequency = "UPDATE_FREQUENCY_DAILY"
+                }
+                refresh_frequency = "UPDATE_FREQUENCY_DAILY"
+            }
+        }
+    }
+    inspect_templates = ["projects/%{project}/inspectTemplates/${google_data_loss_prevention_inspect_template.basic.name}"]
+}
+`, context)
+}
+
+func testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigStartAwsS3(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+}
+resource "google_data_loss_prevention_inspect_template" "basic" {
+    parent = "projects/%{project}"
+    description = "Description"
+    display_name = "Display"
+    inspect_config {
+        info_types {
+            name = "EMAIL_ADDRESS"
+        }
+    }
+}
+resource "google_data_loss_prevention_discovery_config" "basic" {
+    parent = "organizations/%{organization}/locations/%{location}"
+    location = "%{location}"
+	org_config {
+		project_id = "%{project}"
+		location {
+			organization_id = "%{organization}"
+		}
+	}
+	other_cloud_starting_location {
+		aws_location {
+			account_id = "012345678910"
+		}
+	}
+    status = "RUNNING"
+    targets {
+        other_cloud_target {
+			data_source_type {
+				data_source = "aws/s3/bucket"
+			}
+            filter {
+                others {}
+            }
+			generation_cadence {
+                inspect_template_modified_cadence {
+                    frequency = "UPDATE_FREQUENCY_MONTHLY"
+                }
+                refresh_frequency = "UPDATE_FREQUENCY_MONTHLY"
+            }
+        }
+
+    }
+    inspect_templates = ["projects/%{project}/inspectTemplates/${google_data_loss_prevention_inspect_template.basic.name}"]
+}
+`, context)
+}
+
+func testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigUpdateAwsS3(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+}
+resource "google_organization_iam_member" "org_admin" {
+	org_id = "%{organization}"
+	role    = "roles/resourcemanager.organizationAdmin"
+	member = "serviceAccount:service-${data.google_project.project.number}@dlp-api.iam.gserviceaccount.com"
+}
+resource "google_organization_iam_member" "dlp_role" {
+	org_id = "%{organization}"
+	role    = "roles/dlp.orgDriver"
+	member = "serviceAccount:service-${data.google_project.project.number}@dlp-api.iam.gserviceaccount.com"
+}
+resource "google_data_loss_prevention_inspect_template" "basic" {
+    parent = "projects/%{project}"
+    description = "Description"
+    display_name = "Display"
+    inspect_config {
+        info_types {
+            name = "EMAIL_ADDRESS"  
+        }
+    }
+}
+resource "google_data_loss_prevention_discovery_config" "basic" {
+    parent = "organizations/%{organization}/locations/%{location}"
+    location = "%{location}"
+	org_config {
+		project_id = "%{project}"
+		location {
+			organization_id = "%{organization}"
+		}
+	}
+	other_cloud_starting_location {
+		aws_location {
+			account_id = "012345678901"
+		}
+	}
+    status = "RUNNING"
+    targets {
+        other_cloud_target {
+			data_source_type {
+				data_source = "aws/s3/bucket"
+			}
+            filter {
+                collection {
+                    include_regexes {
+                        patterns {
+                            amazon_s3_bucket_regex {
+								aws_account_regex {
+									account_id_regex = "012345678901"
+								}
+                                bucket_name_regex = "bucket"
+                            }
+                        }
+                    }
+                }
+            }
+            conditions {
+                min_age = "10800s"
+                amazon_s3_bucket_conditions {
+					bucket_types = ["TYPE_ALL_SUPPORTED"]
+					object_storage_classes = ["STANDARD", "STANDARD_INFREQUENT_ACCESS"]
+				}
+            }
+            generation_cadence {
+                inspect_template_modified_cadence {
+                    frequency = "UPDATE_FREQUENCY_DAILY"
+                }
+                refresh_frequency = "UPDATE_FREQUENCY_MONTHLY"
+            }
+        }
+    }
+    targets {
+        other_cloud_target {
+			data_source_type {
+				data_source = "aws/s3/bucket"
+			}
+            filter {
+                collection {
+                    include_regexes {
+                        patterns {
+                            amazon_s3_bucket_regex {
+								aws_account_regex {
+									account_id_regex = "012345678901"
+								}
+                                bucket_name_regex = "do-not-scan"
+                            }
+                        }
+                    }
+                }
+            }
+            disabled {}
+        }
+    }
+    targets {
+        other_cloud_target {
+			data_source_type {
+				data_source = "aws/s3/bucket"
+			}
+            filter {
+                others {}
+            }
+            generation_cadence {
+                inspect_template_modified_cadence {
+                    frequency = "UPDATE_FREQUENCY_MONTHLY"
+                }
+                refresh_frequency = "UPDATE_FREQUENCY_MONTHLY"
+            }
+        }
+    }
+    inspect_templates = ["projects/%{project}/inspectTemplates/${google_data_loss_prevention_inspect_template.basic.name}"]
+}
+`, context)
+}
+
+func testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigAwsS3SingleUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+}
+resource "google_organization_iam_member" "org_admin" {
+	org_id = "%{organization}"
+	role    = "roles/resourcemanager.organizationAdmin"
+	member = "serviceAccount:service-${data.google_project.project.number}@dlp-api.iam.gserviceaccount.com"
+}
+resource "google_organization_iam_member" "dlp_role" {
+	org_id = "%{organization}"
+	role    = "roles/dlp.orgDriver"
+	member = "serviceAccount:service-${data.google_project.project.number}@dlp-api.iam.gserviceaccount.com"
+}
+resource "google_data_loss_prevention_inspect_template" "basic" {
+    parent = "projects/%{project}"
+    description = "Description"
+    display_name = "Display"
+    inspect_config {
+        info_types {
+            name = "EMAIL_ADDRESS"  
+        }
+    }
+}
+resource "google_data_loss_prevention_discovery_config" "basic" {
+    parent = "organizations/%{organization}/locations/%{location}"
+    location = "%{location}"
+	org_config {
+		project_id = "%{project}"
+		location {
+			organization_id = "%{organization}"
+		}
+	}
+	other_cloud_starting_location {
+		aws_location {
+			all_asset_inventory_assets = true
+		}
+	}
+    status = "RUNNING"
+    targets {
+        other_cloud_target {
+			data_source_type {
+				data_source = "aws/s3/bucket"
+			}
+            filter {
+                single_resource {
+					amazon_s3_bucket {
+						aws_account {
+							account_id = "012345678901"
+						}
+						bucket_name = "aws_bucket"
+					}
                 }
             }
 			generation_cadence {


### PR DESCRIPTION
…veryTarget, which currently only supports AWS S3 buckets.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:REPLACEME

```
